### PR TITLE
build: loosen jscodeshift peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
     }
   },
   "peerDependencies": {
-    "jscodeshift": "^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0"
+    "jscodeshift": ">=0.7 <1"
   }
 }


### PR DESCRIPTION
Closes #32 

Same as https://github.com/codemodsquad/jscodeshift-add-imports/pull/44.

Supersedes https://github.com/codemodsquad/jscodeshift-find-imports/pull/33